### PR TITLE
Correct typo in nested example

### DIFF
--- a/pages/nested/index.html
+++ b/pages/nested/index.html
@@ -59,7 +59,7 @@
 					<template shadowrootmode="open" adoptstyles="inherit">
 						<p>
 							And when needed, specific sub-trees can still reach the document
-							using <code>adopstyles="initial"</code>.
+							using <code>adoptstyles="initial"</code>.
 
 							<template shadowrootmode="open" adoptstyles="initial">
 								<slot></slot>


### PR DESCRIPTION
Just a small typo I noticed.