### PR TITLE
rename to `adoptHostStyles` and `adoptPageStyles`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ A proof-of-concept implementation of open-styleable shadow-roots, using a combin
 View the hosted examples:
 
 - [basic](https://open-styleable.mynk.app/) ([source](https://github.com/mayank99/open-styleable/blob/main/pages/index.html))
-- [nested shadow-roots](https://open-styleable.mynk.app/nested) ([source](https://github.com/mayank99/open-styleable/blob/main/pages/nested/index.html))
-- [layers](https://open-styleable.mynk.app/layers) ([source](https://github.com/mayank99/open-styleable/blob/main/pages/layers/index.html))
-- [scope](https://open-styleable.mynk.app/scope) ([source](https://github.com/mayank99/open-styleable/blob/main/pages/scope/index.html))
+- [nested shadow-roots](https://open-styleable.mynk.app/nested/) ([source](https://github.com/mayank99/open-styleable/blob/main/pages/nested/index.html))
+- [layers](https://open-styleable.mynk.app/layers/) ([source](https://github.com/mayank99/open-styleable/blob/main/pages/layers/index.html))
+- [scope](https://open-styleable.mynk.app/scope/) ([source](https://github.com/mayank99/open-styleable/blob/main/pages/scope/index.html))
 
 Edit the code live:
 
@@ -26,32 +26,32 @@ The access for open styles is controlled at the shadow-root level. Every shadow-
 
 For [declarative shadow DOM](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_shadow_DOM#declaratively_with_html) (DSD):
 
-- Add `adoptstyles="inherit"` to the DSD template. This shadow-root will now automatically inherit all styles from the host context (i.e. the document or a parent shadow-root).
+- Add the `adopthoststyles` attribute to the DSD template. This shadow-root will now automatically inherit all styles from the host context (i.e. the document or a parent shadow-root).
 
   ```html
-  <template shadowrootmode="open" adoptstyles="inherit">…</template>
+  <template shadowrootmode="open" adopthoststyles>…</template>
   ```
 
-- Alternatively, if you only want to adopt styles from the document and not from the parent shadow-root, then you can use `adoptstyles="initial"`.
+- Alternatively, if you only want to adopt styles from the document and not from the parent shadow-root, then you can use `adoptpagestyles`.
 
   ```html
-  <template shadowrootmode="open" adoptstyles="initial">…</template>
+  <template shadowrootmode="open" adoptpagestyles>…</template>
   ```
 
-For client-rendered shadow-roots, use the `adoptStyles` option when calling `attachShadow`.
+For client-rendered shadow-roots, use the `adoptPageStyles` and `adoptHostStyles` options when calling `attachShadow`.
 
-- Use `adoptStyles: "inherit"` to adopt all styles from the host context.
+- Use `adoptHostStyles` to adopt all styles from the host context.
   ```js
   this.attachShadow({
   	mode: "open",
-  	adoptStyles: "inherit",
+  	adoptHostStyles: true,
   });
   ```
-- Use `adoptStyles: "initial"` to adopt all styles from the document only.
+- Use `adoptPageStyles` to adopt all styles from the page/document only.
   ```js
   this.attachShadow({
   	mode: "open",
-  	adoptStyles: "initial",
+  	adoptPageStyles: true,
   });
   ```
 

--- a/open-styleable-client.js
+++ b/open-styleable-client.js
@@ -7,9 +7,9 @@
 		const shadow = originalAttachShadow.call(this, init);
 
 		let sourceNode;
-		if (init["adoptStyles"] === "initial") {
+		if (init["adoptPageStyles"] === true) {
 			sourceNode = this.ownerDocument;
-		} else if (init["adoptStyles"] === "inherit") {
+		} else if (init["adoptHostStyles"] === true) {
 			sourceNode = shadow.host.getRootNode();
 		}
 

--- a/open-styleable-transform.js
+++ b/open-styleable-transform.js
@@ -20,14 +20,14 @@ export function transformHtml(html) {
 			root.querySelectorAll("link[rel=stylesheet], style")
 		);
 
-		for (const template of templates.filter(
-			(template) => template.getAttribute("adoptstyles") === "initial"
+		for (const template of templates.filter((template) =>
+			template.hasAttribute("adoptpagestyles")
 		)) {
 			template.append(...documentStyles.map((el) => el.cloneNode(true)));
 		}
 
-		for (const template of templates.filter(
-			(template) => template.getAttribute("adoptstyles") === "inherit"
+		for (const template of templates.filter((template) =>
+			template.hasAttribute("adopthoststyles")
 		)) {
 			template.append(...parentStyles.map((el) => el.cloneNode(true)));
 		}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "open-styleable",
 	"type": "module",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"license": "MIT",
 	"repository": {
 		"type": "git",

--- a/pages/index.html
+++ b/pages/index.html
@@ -22,7 +22,7 @@
 		<h1>open-styleable</h1>
 
 		<div>
-			<template shadowrootmode="open" adoptstyles="inherit">
+			<template shadowrootmode="open" adopthoststyles>
 				<p class="shadow">This is inside shadow DOM. (Inspect it!)</p>
 				<slot></slot>
 			</template>
@@ -58,7 +58,7 @@
 				class extends HTMLElement {
 					constructor() {
 						super();
-						this.attachShadow({ mode: "open", adoptStyles: "inherit" });
+						this.attachShadow({ mode: "open", adoptHostStyles: true });
 						this.shadowRoot.innerHTML = `\
 							<p class="shadow">And this is inside a client-rendered shadow-root.</p>
 						`;

--- a/pages/layers/index.html
+++ b/pages/layers/index.html
@@ -48,7 +48,7 @@
 				class extends HTMLElement {
 					constructor() {
 						super();
-						this.attachShadow({ mode: "open", adoptStyles: "initial" });
+						this.attachShadow({ mode: "open", adoptPageStyles: true });
 						this.shadowRoot.innerHTML = `
 						<style>
 							button {

--- a/pages/nested/index.html
+++ b/pages/nested/index.html
@@ -22,8 +22,8 @@
 	<body>
 		<h1>nested shadow-roots</h1>
 		<p>
-			Since <code>adoptstyles</code> is set at the shadow-root level, we don't
-			always have to use it for accessing
+			Since <code>adoptHostStyles</code> gets set at the shadow-root level, we
+			don't always have to use it for accessing
 			<em class="text-brand">page styles</em>.
 		</p>
 
@@ -46,22 +46,21 @@
 				</style>
 
 				<div>
-					<template shadowrootmode="open" adoptstyles="inherit">
+					<template shadowrootmode="open" adopthoststyles>
 						<p>
 							Inner shadow-roots often have full trust in their immediate
-							parent, so <code>adoptstyles="inherit"</code> is perfectly safe
-							here.
+							parent, so <code>adopthoststyles</code> is perfectly safe here.
 						</p>
 					</template>
 				</div>
 
 				<div>
-					<template shadowrootmode="open" adoptstyles="inherit">
+					<template shadowrootmode="open" adopthoststyles>
 						<p>
 							And when needed, specific sub-trees can still reach the document
-							using <code>adoptstyles="initial"</code>.
+							using <code>adoptpagestyles</code>.
 
-							<template shadowrootmode="open" adoptstyles="initial">
+							<template shadowrootmode="open" adoptpagestyles>
 								<slot></slot>
 
 								<em class="text-brand">(Inspect this!)</em>

--- a/pages/scope/index.html
+++ b/pages/scope/index.html
@@ -43,7 +43,7 @@
 			</div>
 
 			<div class="box">
-				<template shadowrootmode="open" adoptstyles="inherit">
+				<template shadowrootmode="open" adopthoststyles>
 					<p class="pink">pink</p>
 				</template>
 			</div>
@@ -60,7 +60,7 @@
 			</div>
 
 			<div class="box">
-				<template shadowrootmode="open" adoptstyles="inherit">
+				<template shadowrootmode="open" adopthoststyles>
 					<p class="blue">blue</p>
 				</template>
 			</div>
@@ -77,7 +77,7 @@
 			</div>
 
 			<div class="box">
-				<template shadowrootmode="open" adoptstyles="inherit">
+				<template shadowrootmode="open" adopthoststyles>
 					<p class="green">green</p>
 				</template>
 			</div>
@@ -107,7 +107,7 @@
 						super();
 						this.attachShadow({
 							mode: "open",
-							adoptStyles: "inherit",
+							adoptHostStyles: true,
 						}).innerHTML = `<p class=${this.dataset.color}>${this.dataset.color}</p>`;
 					}
 				}


### PR DESCRIPTION
Having these two as separate, if verbosely named, attributes would be less confusing, compared to overloading the concept of `initial`/`inherit` which already has a different meaning in CSS.

```html
<template shadowrootmode="open" adopthoststyles>
```

```html
<template shadowrootmode="open" adoptpagestyles>
```

---

Note: `@sheet`s can still be supported. It's actually less ambiguous now, since we know exactly where to look for sheets.

These sheet names are to be defined in the host:
```
adopthoststyles="sheet1 sheet3"
```

While these should be defined at the page level:
```
adoptpagestyles="sheet2 sheet4"
```
